### PR TITLE
Minor change to clean to avoid explicit naming of subdirectories.

### DIFF
--- a/src/Makefile.targets
+++ b/src/Makefile.targets
@@ -218,8 +218,8 @@ clean:
 
 	@-$(RM) $(HEADER_DEPENDS)
 
-	@-for dir in dependencies/challenges dependencies/input_management dependencies/python_embed dependencies/gui dependencies; do \
-		if [ -d $${dir} ]; then ${RMDIR} $${dir}; fi; \
+	@-for directory in dependencies/* dependencies; do \
+	  if [ -d $${directory} ]; then ${RMDIR} $${directory}; fi; \
 	done
 
 	@echo "${bold}${green}Made clean${normal}"


### PR DESCRIPTION
The move of tests to experimental raised an issue regarding subdirectories of dependencies so this is a minor change to remove explicit naming and just using a glob.
