### PR TITLE
Only set COMPILER if it isn't set in the environment

### DIFF
--- a/src/Makefile.settings
+++ b/src/Makefile.settings
@@ -4,7 +4,9 @@ RM = rm -f
 RMDIR = rmdir
 MKDIR = mkdir -p
 
-COMPILER = g++
+ifeq "$(COMPILER)" ""
+	COMPILER = g++
+endif
 
 WARNINGS = \
 	-isystem ./catch                \


### PR DESCRIPTION
The README instructions say to override `COMPILER` as an environment variable, but by default `make` gives precedence to variables defined in makefiles over environment variables, so the `COMPILER = g++` line in `src/Makefile.settings` means the environment variable is ignored.

This change only sets the variable if it doesn't already have a value, allowing the README instructions to work as intended.
