### PR TITLE
std::thread is movable, no need to use unique_ptr.

### DIFF
--- a/src/python_embed/entitythread.cpp
+++ b/src/python_embed/entitythread.cpp
@@ -175,7 +175,7 @@ EntityThread::EntityThread(InterpreterContext interpreter_context, Entity &entit
             entity_object = std::make_shared<py::api::object>(boost::ref(entity));
         };
 
-        thread = std::make_unique<std::thread>(
+        thread = std::thread(
             run_entity,
             std::ref(thread_finished),
             entity_object,
@@ -235,7 +235,7 @@ void EntityThread::finish() {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
-    thread->join();
+    thread.join();
 }
 
 EntityThread::~EntityThread() {

--- a/src/python_embed/entitythread.hpp
+++ b/src/python_embed/entitythread.hpp
@@ -74,7 +74,7 @@ class EntityThread {
         ///
         /// Thread spawned by this EntityThread.
         ///
-        std::unique_ptr<std::thread> thread;
+        std::thread thread;
 
         ///
         /// Stores the call count from last time clean was called.


### PR DESCRIPTION
A `std::thread` is already a unique handle on a resource, there is no need to allocate it on the heap and store it in a `unique_ptr`.
