### PR TITLE
adding get_position API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ Keybindings
 * `look(radius)` - Find all objects in a given radius from the character. Parameter: radius of the area to search for objects in.
 
 * `monologue()` - Prints to the screen the name and location of a character.
+* `get_position()` - Returns a tuple of the position of the character.

--- a/src/python_embed/api.cpp
+++ b/src/python_embed/api.cpp
@@ -75,6 +75,22 @@ void Entity::monologue() {
     });
 }
 
+int Entity::get_x_position() {
+    auto id(this->id);
+    return GilSafeFuture<int>::execute([id] (GilSafeFuture<int> position) {
+        auto where(Engine::find_object(id));
+        position.set(int(where.x));
+    });
+}
+
+int Entity::get_y_position() {
+    auto id(this->id);
+    return GilSafeFuture<int>::execute([id] (GilSafeFuture<int> position) {
+        auto where(Engine::find_object(id));
+        position.set(int(where.y));
+    });
+}
+
 bool Entity::cut(int x, int y) {
     ++call_number;
 

--- a/src/python_embed/api.hpp
+++ b/src/python_embed/api.hpp
@@ -127,6 +127,9 @@ class Entity {
 
         py::list get_retrace_steps();
         py::object read_message();
+
+        int get_x_position();
+        int get_y_position();
 };
 
 

--- a/src/python_embed/scripts/bootstrapper.py
+++ b/src/python_embed/scripts/bootstrapper.py
@@ -132,6 +132,13 @@ def create_execution_scope(entity, RESTART, STOP, KILL):
 
         entity._print_debug(text)
 
+    def get_position():
+        """
+        Returns character current position as an tuple of x position and y position.
+        """
+
+        return (entity.get_x_position(), entity.get_y_position())
+
     imbued_locals = {
         "north": north,
         "south": south,
@@ -146,6 +153,7 @@ def create_execution_scope(entity, RESTART, STOP, KILL):
         "monologue": monologue,
         "read_message": read_message,
         "walkable": walkable,
+        "get_position":get_position,
 
         "_print_debug": _print_debug
     }

--- a/src/python_embed/wrapper_functions.cpp
+++ b/src/python_embed/wrapper_functions.cpp
@@ -22,5 +22,7 @@ BOOST_PYTHON_MODULE(wrapper_functions) {
         .def("print_dialogue",    &Entity::py_print_dialogue)
         .def("read_message",      &Entity::read_message)
         .def("update_status",     &Entity::py_update_status)
-        .def("walkable",          &Entity::walkable);
+        .def("walkable",          &Entity::walkable)
+        .def("get_x_position",    &Entity::get_x_position)
+        .def("get_y_position",    &Entity::get_y_position);
 }


### PR DESCRIPTION
this code adds the get_position() API call, as requested in #105 by @davidhoness and @asb.

This approach has code duplication in api.cpp where there are separate get_x_position() and get_y_position methods, as I wasn't sure about how to return a tuples through the C++/Python interface. I would appreciate if someone (e.g. @Veedrac or @bencatterall) can fix this.
