### PR TITLE
Three small updates…

### DIFF
--- a/src/Makefile.targets
+++ b/src/Makefile.targets
@@ -1,6 +1,7 @@
 all: $(EXECUTABLE) python_embed/wrapper_functions.so
 
 test: all $(TEST_EXECUTABLE)
+	$(TEST_EXECUTABLE)
 
 debug: CXXFLAGS += -g
 debug: CXXFLAGS += -O0

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -214,7 +214,7 @@ void Engine::open_editor(std::string filename) {
     std::string command(editor + std::string(" python_embed/scripts/") + filename +  ".py");
 
     // TODO: Make this close safely.
-    std::thread([command] () { system(command.c_str()); }).detach();
+    std::thread([command] () { return system(command.c_str()); }).detach();
 }
 
 static std::vector<int> location_filter_objects(glm::vec2 location, std::vector<int> objects) {

--- a/src/tmx-parser/Makefile.linux
+++ b/src/tmx-parser/Makefile.linux
@@ -54,9 +54,9 @@ libtmxparser.a: $(OBJECTS)
 
 clean:
 	@echo "removing -- objects"
-	@rm $(OBJECTS)
+	@rm -f $(OBJECTS)
 	@echo "removing -- library"
-	@rm libtmxparser.a
+	@rm -f libtmxparser.a
 
 install:
 	@echo "installing -- headers"


### PR DESCRIPTION
1. Actually run the tests on "make test".

2. Added -f option to rm in a Makefile to avoid error message on repeated cleaning.

3. Returned the exit code of the system() call so as to avoid a warning message which then becomes an error.